### PR TITLE
Designate a random amount of targets to be impacted

### DIFF
--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_cpu.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_cpu.yaml
@@ -12,6 +12,8 @@ spec:
   container_filter: "n([a-z])inx"
   restart_on_filaure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_disk.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_disk.yaml
@@ -14,8 +14,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_dns.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_dns.yaml
@@ -13,8 +13,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_io.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_io.yaml
@@ -15,8 +15,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_latency.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_latency.yaml
@@ -17,8 +17,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_memory.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_memory.yaml
@@ -13,8 +13,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_packet_loss.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_packet_loss.yaml
@@ -17,8 +17,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_process_killer.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_process_killer.yaml
@@ -19,8 +19,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/crds/gremlin_v1alpha1_gremlin_cr_shutdown.yaml
+++ b/deploy/crds/gremlin_v1alpha1_gremlin_cr_shutdown.yaml
@@ -11,8 +11,10 @@ spec:
   labels:
     app: nginx
   container_filter: "n([a-z])inx"
-  restart_on_filaure: false
+  restart_on_failure: false
   schedule: "*/1 * * * *"
+  impact_percentage: 100
+  impact_count: 1
   config_override:
     team_id: ""
     team_private_key: ""

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -35,7 +35,7 @@ spec:
             - name: GREMLIN_TEAM_ID
               value: ""
             - name: "GREMLIN_TEAM_CERTIFICATE"
-              value: "gremlin-cert"
+              value: "gremlin-team-cert"
             - name: "GREMLIN_TEAM_CERTIFICATE_SECRET_KEY"
               value: "gremlin.cert"
             - name: "GREMLIN_TEAM_KEY_SECRET_KEY"

--- a/pkg/apis/gremlin/v1alpha1/gremlin_types.go
+++ b/pkg/apis/gremlin/v1alpha1/gremlin_types.go
@@ -57,6 +57,10 @@ type GremlinSpec struct {
 	KillChildren bool   `json:"kill_children,omitempty"`
 	Full         bool   `json:"full,omitempty"`
 
+	// Impact
+	ImpactPercentage uint `json:"impact_percentage,omitempty"`
+	ImpactCount      uint `json:"impact_count,omitempty"`
+
 	// Schedule
 	Schedule string `json:"schedule,omitempty"`
 	// Shutdown attack
@@ -68,7 +72,7 @@ type GremlinSpec struct {
 	ContainerFilter string            `json:"container_filter,omitempty"`
 	Labels          map[string]string `json:"labels"`
 
-	RestartOnFailure bool `json:"restart_on_filaure,omitempty"`
+	RestartOnFailure bool `json:"restart_on_failure,omitempty"`
 }
 
 // ConfigOverride defines the parameters acceptable for override


### PR DESCRIPTION
* Add two options
  - `impact_percentage` - Target pods as percentage. if defined takes priority over impact_count variable, the default is zero. integer
     Note: Percentages values will always be the floor of output number
  - `impact_count` - default 1, number of pods will to be targetted as a number

Use `lables` and `container_filter` to narrow the number of selected targets.